### PR TITLE
Resolve some NU1608 warnings in the eShopOnContainersDDD

### DIFF
--- a/src/Contexts/Basket/Applications/Tests/Basket.Applications.Tests.csproj
+++ b/src/Contexts/Basket/Applications/Tests/Basket.Applications.Tests.csproj
@@ -18,13 +18,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Aggregates.NET.Testing" Version="0.15.36.892" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Contexts/Basket/Domain/Tests/Basket.Domain.Tests.csproj
+++ b/src/Contexts/Basket/Domain/Tests/Basket.Domain.Tests.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="Aggregates.NET.Testing" Version="0.15.36.892" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Contexts/Catalog/Domain/Tests/Catalog.Domain.Tests.csproj
+++ b/src/Contexts/Catalog/Domain/Tests/Catalog.Domain.Tests.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="Aggregates.NET.Testing" Version="0.15.36.892" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Contexts/Identity/Domain/Tests/Identity.Domain.Tests.csproj
+++ b/src/Contexts/Identity/Domain/Tests/Identity.Domain.Tests.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="Aggregates.NET.Testing" Version="0.15.36.892" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Contexts/Ordering/Domain/Tests/Ordering.Domain.Tests.csproj
+++ b/src/Contexts/Ordering/Domain/Tests/Ordering.Domain.Tests.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="Aggregates.NET.Testing" Version="0.15.36.892" />
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.16.0" />
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi, I found some NU1608 warnings in the eShopOnContainersDDD:

`Warning NU1608 Detected package version outside of dependency constraint: AutoFixture.AutoFakeItEasy 4.11.0 requires FakeItEasy (>= 4.9.0 && < 6.0.0) but version FakeItEasy 6.0.0 was resolved. Catalog.Domain.Tests	D:\VS Commits\local\eShopOnContainersDDD\src\Contexts\Catalog\Domain\Tests\Catalog.Domain.Tests.csproj`
`Warning NU1608 Detected package version outside of dependency constraint: AutoFixture.AutoFakeItEasy 4.11.0 requires FakeItEasy (>= 4.9.0 && < 6.0.0) but version FakeItEasy 6.0.0 was resolved. Basket.Applications.Tests	D:\VS Commits\local\eShopOnContainersDDD\src\Contexts\Basket\Applications\Tests\Basket.Applications.Tests.csproj`
`Warning NU1608 Detected package version outside of dependency constraint: AutoFixture.AutoFakeItEasy 4.11.0 requires FakeItEasy (>= 4.9.0 && < 6.0.0) but version FakeItEasy 6.0.0 was resolved. Identity.Domain.Tests	D:\VS Commits\local\eShopOnContainersDDD\src\Contexts\Identity\Domain\Tests\Identity.Domain.Tests.csproj`
`Warning NU1608 Detected package version outside of dependency constraint: AutoFixture.AutoFakeItEasy 4.11.0 requires FakeItEasy (>= 4.9.0 && < 6.0.0) but version FakeItEasy 6.0.0 was resolved. Ordering.Domain.Tests	D:\VS Commits\local\eShopOnContainersDDD\src\Contexts\Ordering\Domain\Tests\Ordering.Domain.Tests.csproj`
`Warning NU1608 Detected package version outside of dependency constraint: AutoFixture.AutoFakeItEasy 4.11.0 requires FakeItEasy (>= 4.9.0 && < 6.0.0) but version FakeItEasy 6.0.0 was resolved. Ordering.Domain.Tests	Basket.Domain.Tests	D:\VS Commits\local\eShopOnContainersDDD\src\Contexts\Basket\Domain\Tests\Basket.Domain.Tests.csproj`

This fix can remove this warnings from eShopOnContainersDDD's dependency graph.
Hope the PR can help you.

Best regards,
sucrose